### PR TITLE
Update AGP, Kotlin, Gradle and dependencies

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CMakeSettings">
     <configurations>

--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ Add the dependency to your project:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.projectdelta6:flexilogger:2.1.0")
+            implementation("io.github.projectdelta6:flexilogger:2.1.1")
 
             // Optional: Ktor HTTP logging (all platforms)
-            implementation("io.github.projectdelta6:flexilogger-ktor:2.1.0")
+            implementation("io.github.projectdelta6:flexilogger-ktor:2.1.1")
         }
 
         // Optional: OkHttp HTTP logging (JVM/Android only)
         jvmMain.dependencies {
-            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.0")
+            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.1")
         }
         androidMain.dependencies {
-            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.0")
+            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.1")
         }
     }
 }
@@ -49,8 +49,8 @@ kotlin {
 **Android/JVM only:**
 ```kotlin
 dependencies {
-    implementation("io.github.projectdelta6:flexilogger:2.1.0")
-    implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.0")  // Optional
+    implementation("io.github.projectdelta6:flexilogger:2.1.1")
+    implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.1")  // Optional
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "37"
 targetSdk = "37"
 minSdk = "21"
-flexiLoggerVersion = "2.1.0"
+flexiLoggerVersion = "2.1.1"
 # Plugin versions
 agp = "9.2.0"
 kotlin = "2.3.21"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-compileSdk = "36"
-targetSdk = "36"
+compileSdk = "37"
+targetSdk = "37"
 minSdk = "21"
 flexiLoggerVersion = "2.1.0"
 # Plugin versions
-agp = "9.0.0"
-kotlin = "2.3.10"
+agp = "9.2.0"
+kotlin = "2.3.21"
 vanniktechPublish = "0.36.0"
 
 # Library versions
-core-ktx = "1.17.0"
+core-ktx = "1.18.0"
 appcompat = "1.7.1"
-material = "1.13.0"
+material = "1.13.1"
 constraintlayout = "2.2.1"
 junit = "4.13.2"
 androidx-test-ext = "1.3.0"
 espresso = "3.7.0"
 loggingInterceptor = "5.3.2"
-ktor = "3.4.0"
+ktor = "3.4.3"
 
 [libraries]
 # Androidx dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Bumps AGP (9.0.0 → 9.2.0), Kotlin (2.3.10 → 2.3.21) and Gradle wrapper (9.1.0 → 9.4.1)
- Raises compileSdk/targetSdk from 36 → 37
- Refreshes core-ktx (1.17.0 → 1.18.0), Material (1.13.0 → 1.13.1) and Ktor (3.4.0 → 3.4.3)

## Notes
- All other dependencies were already at their latest stable versions (checked 2026-04-24); only pre-release versions were newer.
- Project build scripts and source already use the modern AGP 9 / Kotlin 2.3 KMP DSL — no deprecation fixes needed.

## Test plan
- [x] Sync project in Android Studio
- [x] Build all library modules (`:flexilogger`, `:flexilogger-okhttp`, `:flexilogger-ktor`)
- [x] Build and run `TestApp` on Android
- [ ] Run `allTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)