### PR TITLE
Fix JVM artifacts to target Java 11 bytecode (2.1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ jobs:
       - name: Run tests and verify coverage
         run: ./gradlew allTests koverVerify
 
+      # Guard against the 2.1.3 regression: published JVM bytecode must stay at/below
+      # Java 11 (class-file major 55). Without the jvmTarget pin, CI's JDK would leak
+      # a higher major here and fail the check.
+      - name: Verify JVM bytecode level (<= Java 11 / major 55)
+        run: |
+          ./gradlew compileKotlinJvm
+          bad=0
+          while IFS= read -r cls; do
+            major=$(od -An -tu1 -j6 -N2 "$cls" | awk '{print $2}')
+            if [ "$major" -gt 55 ]; then
+              echo "::error file=$cls::JVM bytecode major $major (Java $((major-44))) exceeds Java 11 (major 55)"
+              bad=1
+            fi
+          done < <(find . -path '*/build/classes/kotlin/jvm/main/*' -name '*.class')
+          if [ "$bad" -ne 0 ]; then
+            echo "JVM bytecode level check FAILED"; exit 1
+          fi
+          echo "All JVM main classes are <= Java 11 bytecode (major 55)."
+
       - name: Upload Kover coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.3] - Unreleased
+## [2.1.3] - 2026-06-04
 
 ### Fixed
 - **JVM artifacts now target Java 11 bytecode (major 55) again.** The `jvm()` target
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JavaScript (Browser/Node.js) alongside Android.
 - OkHttp integration package renamed: `com.duck.flexihttplogger` → `com.duck.flexilogger.okhttp`.
 
-[2.1.3]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.2...HEAD
+[2.1.3]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/projectdelta6/FlexiLogger/compare/v2.0.0...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - Unreleased
+
+### Fixed
+- **JVM artifacts now target Java 11 bytecode (major 55) again.** The `jvm()` target
+  wasn't pinning `jvmTarget`, so it inherited the build JDK and the `*-jvm` artifacts for
+  `2.0.0`–`2.1.2` shipped as Java 24 bytecode (major 68) — unloadable on older JDKs with
+  `UnsupportedClassVersionError`. Pure-JVM (non-Android) consumers on a JDK below 24 were
+  affected; the `-android` variant was always correct. Pinned `jvmTarget = JVM_11` on the
+  `jvm()` target of all three modules.
+
+### Added
+- CI now asserts JVM main classes are ≤ Java 11 bytecode, so this regression can't return silently.
+
 ## [2.1.2] - 2026-06-04
 
 ### Fixed
@@ -61,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JavaScript (Browser/Node.js) alongside Android.
 - OkHttp integration package renamed: `com.duck.flexihttplogger` → `com.duck.flexilogger.okhttp`.
 
+[2.1.3]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.2...HEAD
 [2.1.2]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/projectdelta6/FlexiLogger/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/projectdelta6/FlexiLogger/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ Add the dependency to your project:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.projectdelta6:flexilogger:2.1.2")
+            implementation("io.github.projectdelta6:flexilogger:2.1.3")
 
             // Optional: Ktor HTTP logging (all platforms)
-            implementation("io.github.projectdelta6:flexilogger-ktor:2.1.2")
+            implementation("io.github.projectdelta6:flexilogger-ktor:2.1.3")
         }
 
         // Optional: OkHttp HTTP logging (JVM/Android only)
         jvmMain.dependencies {
-            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.2")
+            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.3")
         }
         androidMain.dependencies {
-            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.2")
+            implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.3")
         }
     }
 }
@@ -49,8 +49,8 @@ kotlin {
 **Android/JVM only:**
 ```kotlin
 dependencies {
-    implementation("io.github.projectdelta6:flexilogger:2.1.2")
-    implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.2")  // Optional
+    implementation("io.github.projectdelta6:flexilogger:2.1.3")
+    implementation("io.github.projectdelta6:flexilogger-okhttp:2.1.3")  // Optional
 }
 ```
 
@@ -427,6 +427,14 @@ data class CallSite(
 | JS       | `console.log/info/warn/error` | `obj::class.simpleName`      |
 
 ## Migration
+
+### From 2.0.0–2.1.2 to 2.1.3
+
+**JVM bytecode fix.** The `*-jvm` artifacts for `2.0.0`–`2.1.2` were accidentally compiled
+to Java 24 bytecode, so pure-JVM (non-Android) consumers on a JDK below 24 hit
+`UnsupportedClassVersionError`. `2.1.3` restores Java 11 bytecode. If you worked around this
+by bumping your build to JDK 24, you can revert that once on `2.1.3`. **No code or API
+changes** — Android consumers were never affected.
 
 ### From 2.1.1 to 2.1.2
 

--- a/flexilogger-ktor/build.gradle.kts
+++ b/flexilogger-ktor/build.gradle.kts
@@ -22,7 +22,14 @@ kotlin {
     }
 
     // JVM target (Desktop)
-    jvm()
+    jvm {
+        // Pin bytecode to JVM 11 (matching the Android target). Without this the
+        // jvm() target inherits the build JDK's level, shipping unusable artifacts
+        // to consumers on older JDKs (see CHANGELOG 2.1.3).
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
 
     // iOS targets
     iosX64()

--- a/flexilogger-okhttp/build.gradle.kts
+++ b/flexilogger-okhttp/build.gradle.kts
@@ -22,7 +22,14 @@ kotlin {
     }
 
     // JVM target (Desktop)
-    jvm()
+    jvm {
+        // Pin bytecode to JVM 11 (matching the Android target). Without this the
+        // jvm() target inherits the build JDK's level, shipping unusable artifacts
+        // to consumers on older JDKs (see CHANGELOG 2.1.3).
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
 
     // Source sets
     sourceSets {

--- a/flexilogger/build.gradle.kts
+++ b/flexilogger/build.gradle.kts
@@ -22,7 +22,14 @@ kotlin {
     }
 
     // JVM target (Desktop)
-    jvm()
+    jvm {
+        // Pin bytecode to JVM 11 (matching the Android target). Without this the
+        // jvm() target inherits the build JDK's level, shipping unusable artifacts
+        // to consumers on older JDKs (see CHANGELOG 2.1.3).
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
 
     // iOS targets
     iosX64()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "37"
 targetSdk = "37"
 minSdk = "21"
-flexiLoggerVersion = "2.1.2"
+flexiLoggerVersion = "2.1.3"
 # Plugin versions
 agp = "9.2.1"
 kotlin = "2.4.0"


### PR DESCRIPTION
## The bug

The `jvm()` Kotlin target wasn't pinning `jvmTarget`, so it inherited the **build JDK's** bytecode level. The `*-jvm` artifacts for **2.0.0–2.1.2** shipped as **Java 24 bytecode (class-file major 68)** and fail to load on older JDKs with `UnsupportedClassVersionError`. Only pure-JVM (non-Android) consumers below JDK 24 were affected — the `-android` variant always pinned `JVM_11`.

Found downstream in AppolyDroid Toolbox, where a `java-library` module depending on `flexilogger` failed at test time on JDK 21.

## The fix

- Pin `jvmTarget = JVM_11` on the `jvm()` target of **flexilogger**, **flexilogger-okhttp**, and **flexilogger-ktor**.
- **Verified locally** — the compiled `jvm` main classes are now **major 55 (Java 11)** across all three modules (were 68).

## Regression guard

- New CI step asserts every JVM main class stays **≤ Java 11 (major 55)**. Since CI builds on JDK 21, an unpinned target would leak major 65 here and fail the check — so this can't silently come back.

## Release

- Version bumped to **2.1.3**; CHANGELOG entry + README migration note (covering `2.0.0–2.1.2 → 2.1.3`).
- Downstream workaround (bump consumer build to JDK 24) can be reverted once on 2.1.3.

## Before merge / tagging
- [ ] Flip CHANGELOG `[2.1.3] - Unreleased` → release date, and `compare/v2.1.2...HEAD` → `...v2.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)